### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "react",
     "router"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/larrymyers/react-mini-router"
+  },
   "bugs": {
     "url": "https://github.com/larrymyers/react-mini-router/issues"
   },


### PR DESCRIPTION
This will stop warnings when installing through npm as well as include a link to the repo on the npm website package page.