### PR TITLE
Add support for nested routes

### DIFF
--- a/lib/RouterMixin.js
+++ b/lib/RouterMixin.js
@@ -4,6 +4,26 @@ var pathToRegexp = require('path-to-regexp'),
 
 module.exports = {
 
+    contextTypes: {
+        path: React.PropTypes.string,
+        root: React.PropTypes.string,
+        useHistory: React.PropTypes.bool
+    },
+
+    childContextTypes: {
+        path: React.PropTypes.string,
+        root: React.PropTypes.string,
+        useHistory: React.PropTypes.bool
+    },
+
+    getChildContext: function() {
+        return {
+            path: this.state.path,
+            root: this.state.root,
+            useHistory: this.state.useHistory
+        }
+    },
+
     getDefaultProps: function() {
         return {
             routes: {}
@@ -12,9 +32,9 @@ module.exports = {
 
     getInitialState: function() {
         return {
-            path: this.props.path,
-            root: this.props.root || '',
-            useHistory: this.props.history && detect.hasPushState
+            path: this.props.path || this.context.path,
+            root: (this.context.root || '') + (this.props.root || ''),
+            useHistory: (this.props.history || this.context.useHistory) && detect.hasPushState
         };
     },
 

--- a/test/RouterMixin-test.js
+++ b/test/RouterMixin-test.js
@@ -5,7 +5,7 @@ var assert = require('assert'),
     RouterMixin = require('./../lib/RouterMixin'),
     navigate = require('./../lib/navigate');
 
-var App, AppWithoutNotFound;
+var App, AppWithoutNotFound, NestedApp;
 
 describe('RouterMixin', function() {
 
@@ -85,6 +85,15 @@ describe('RouterMixin', function() {
         }, 100);
     });
 
+    it('Should render the nested app.', function() {
+        React.render(
+            App({ path: '/nested' }),
+            $('.app').get(0)
+        );
+
+        assert.equal($('.nested').length, 1);
+    });
+
     // TODO when PhantomJS 2.0 is out, we'll have pushState support, implement a test for it then.
 });
 
@@ -94,7 +103,8 @@ var AppClass = React.createClass({
 
     routes: {
         '/': 'home',
-        '/search/:searchQuery': 'searchResults'
+        '/search/:searchQuery': 'searchResults',
+        '/nested/:path*': 'nestedApp'
     },
 
     render: function() {
@@ -107,6 +117,10 @@ var AppClass = React.createClass({
 
     searchResults: function(searchQuery, params) {
         return React.DOM.div({ className: 'search-results'}, searchQuery);
+    },
+
+    nestedApp: function() {
+        return NestedApp({ root: '/nested' });
     },
 
     notFound: function(path) {
@@ -133,5 +147,24 @@ var AppWithoutNotFoundClass = React.createClass({
 
 });
 
+var NestedAppClass = React.createClass({
+
+    mixins: [RouterMixin],
+
+    routes: {
+        '/': 'home'
+    },
+
+    render: function() {
+        return this.renderCurrentRoute();
+    },
+
+    home: function() {
+        return React.DOM.div({ className: 'nested' }, 'test');
+    }
+
+});
+
 App = React.createFactory(AppClass);
 AppWithoutNotFound = React.createFactory(AppWithoutNotFoundClass);
+NestedApp = React.createFactory(NestedAppClass);


### PR DESCRIPTION
I really like the simplicity of this router. It's also the only one that works seamlessly with the prerendering in react-rails. However, in the application I'm working on the top-level component is starting to get pretty big and I really wanted to break it into smaller pieces.

These changes make it possible to nest routers similar to [contextual routers](http://strml.viewdocs.io/react-router-component/contextual) in react-router-component. It was surprisingly simple thanks to the already supported `root` prop. Essentially the router state is just mirrored onto the child context that the nested routers then use as their default state.

I added one simple test case, but you just let me know if you want anything more specific.