### PR TITLE
fix getInitialPath to get correct path while hash is null

### DIFF
--- a/lib/RouterMixin.js
+++ b/lib/RouterMixin.js
@@ -153,10 +153,10 @@ function getInitialPath(component) {
     if (!path && detect.canUseDOM) {
         url = urllite(window.location.href);
 
-        if (!component.props.useHistory && url.hash) {
-            path = urllite(url.hash.slice(2)).pathname;
-        } else {
+        if (component.props.useHistory) {
             path = url.pathname;
+        } else if (url.hash) {
+            path = urllite(url.hash.slice(2)).pathname;
         }
     }
 


### PR DESCRIPTION
Hi. I got something like `Uncaught Error: No route matched path: /admin` in the console after update to 1.1.0.
This patch fixes this bug when not using history api.