### PR TITLE
Fix getInitialPath to use props.history instead of props.useHistory

### DIFF
--- a/lib/RouterMixin.js
+++ b/lib/RouterMixin.js
@@ -153,7 +153,7 @@ function getInitialPath(component) {
     if (!path && detect.canUseDOM) {
         url = urllite(window.location.href);
 
-        if (component.props.useHistory) {
+        if (component.props.history) {
             path = url.pathname + url.search;
         } else if (url.hash) {
             hash = urllite(url.hash.slice(2));


### PR DESCRIPTION
Uncaught Error: No route matched path: / when used on a page in a
subdirectory. Example: http://server/subdir/subdir/page

The documentation states { history : true } should be passed to the
component which get attached to the component’s props. useHistory
becomes a property of the component state which isn’t available yet
when getInitialPath is called.