### PR TITLE
Fix IE error caused by lack of DOM L4 event constructor pattern

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+msvs-version=2013
+python=python3.1

--- a/lib/detect.js
+++ b/lib/detect.js
@@ -9,5 +9,8 @@ module.exports = {
     hasPushState: canUseDOM && window.history && 'pushState' in window.history,
     hasHashbang: function() {
         return canUseDOM && window.location.hash.indexOf('#!') === 0;
+    },
+    hasEventConstructor: function() {
+      return typeof window.Event == "function";
     }
 };

--- a/lib/event.js
+++ b/lib/event.js
@@ -1,0 +1,13 @@
+var detect = require('./detect');
+
+module.exports = {
+    createEvent: function(name) {
+      if (detect.hasEventConstructor()) {
+        return new window.Event(name);
+      } else {
+        var event = document.createEvent('Event');
+        event.initEvent(name, true, false);
+        return event;
+      }
+    }
+};

--- a/lib/navigate.js
+++ b/lib/navigate.js
@@ -1,11 +1,12 @@
 var detect = require('./detect');
+var event = require('./event');
 
 module.exports = function triggerUrl(url, silent) {
     if (detect.hasHashbang()) {
         window.location.hash = '#!' + url;
     } else if (detect.hasPushState) {
         window.history.pushState({}, '', url);
-        if (!silent) window.dispatchEvent(new window.Event('popstate'));
+        if (!silent) window.dispatchEvent(event.createEvent('popstate'));
     } else {
         console.error("Browser does not support pushState, and hash is missing a hashbang prefix!");
     }


### PR DESCRIPTION
Fixed an error caused in navigation by the lack of support for event
constructors in IE, Edge adds support for this feature.

Detect includes new hasEventConstructor method and new events file to
create events based on browser support.

Fixes issue #33 