### PR TITLE
Address #65, updating dependencies for karma, react, inlining getEventTarget

### DIFF
--- a/lib/RouterMixin.js
+++ b/lib/RouterMixin.js
@@ -1,7 +1,7 @@
 var React = require('react'),
     ReactDOM = require('react-dom'),
     EventListener = require('fbjs/lib/EventListener'),
-    getEventTarget = require('react/lib/getEventTarget'),
+    getEventTarget = require('./getEventTarget'),
     pathToRegexp = require('path-to-regexp'),
     urllite = require('urllite/lib/core'),
     detect = require('./detect');

--- a/lib/getEventTarget.js
+++ b/lib/getEventTarget.js
@@ -1,0 +1,25 @@
+// addressing https://github.com/larrymyers/react-mini-router/issues/65
+// this code taken from https://raw.githubusercontent.com/facebook/react/v15.3.2/src/renderers/dom/client/utils/getEventTarget.js
+'use strict';
+
+/**
+ * Gets the target node from a native browser event by accounting for
+ * inconsistencies in browser DOM APIs.
+ *
+ * @param {object} nativeEvent Native browser event.
+ * @return {DOMEventTarget} Target node.
+ */
+function getEventTarget(nativeEvent) {
+  var target = nativeEvent.target || nativeEvent.srcElement || window;
+
+  // Normalize SVG <use> element events #4963
+  if (target.correspondingUseElement) {
+    target = target.correspondingUseElement;
+  }
+
+  // Safari may fire events on text nodes (Node.TEXT_NODE is 3).
+  // @see http://www.quirksmode.org/js/events_properties.html
+  return target.nodeType === 3 ? target.parentNode : target;
+}
+
+module.exports = getEventTarget;

--- a/package.json
+++ b/package.json
@@ -36,16 +36,16 @@
   "devDependencies": {
     "cheerio": "^0.18.0",
     "console-polyfill": "^0.2.1",
-    "karma": "^0.13.11",
+    "karma": "^1.3.0",
     "karma-chrome-launcher": "^0.1.7",
-    "karma-cli": "0.0.4",
+    "karma-cli": "1.0.1",
     "karma-mocha": "^0.1.10",
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-sauce-launcher": "^0.2.10",
     "karma-webpack": "^1.7.0",
     "mocha": "^2.1.0",
-    "react": ">=0.12.0",
-    "react-dom": "^0.14.0",
+    "react": "^15.4.1",
+    "react-dom": "^15.4.1",
     "uglify-js": "^2.4.15",
     "webpack": "^1.12.2"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mini-router",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A small url router for React apps.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Forking to address #65 upstream (related: https://github.com/larrymyers/react-mini-router/issues/66).

This updates dependencies for karma-cli and karma to work under Node 6:
```
$ npm install
...
npm ERR! notsup Unsupported engine for karma-cli@0.0.4: wanted: {"node":"~0.8 || ~0.10"} (current: {"node":"6.2.1","npm":"3.9.3"})
...
npm ERR! notsup Unsupported engine for karma@0.13.22: wanted: {"node":"0.10 || 0.12 || 4 || 5"} (current: {"node":"6.2.1","npm":"3.9.3"})
...
```

And updates react and react-dom to 15.4.1:
```
$ npm test
...
PhantomJS 1.9.8 (Mac OS X 0.0.0) ERROR
  Error: Cannot find module "react/lib/ReactDOM"
  at undefined:3
...
```

And fixes the underlying issue with `getEventTarget` no longer being exposed by React by inlining the [version that was previously in React 15.3.2](https://github.com/facebook/react/blob/v15.3.2/src/renderers/dom/client/utils/getEventTarget.js):
```
$ npm test
...
PhantomJS 1.9.8 (Mac OS X 0.0.0) ERROR
  Error: Cannot find module "react/lib/getEventTarget"
  at undefined:4
...
```

@larrymyers I'm not sure how you'd like to manage the project, but if this is useful merge away!