### PR TITLE
Fixed dependendencies to get tests to pass on Mac os Sierra

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mini-router",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A small url router for React apps.",
   "main": "index.js",
   "scripts": {
@@ -25,8 +25,8 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "react": ">=0.14.0",
-    "react-dom": ">=0.14.0"
+    "react": ">=15.4.1",
+    "react-dom": ">=15.4.1"
   },
   "dependencies": {
     "fbjs": "^0.3.2",
@@ -40,7 +40,7 @@
     "karma-chrome-launcher": "^0.1.7",
     "karma-cli": "1.0.1",
     "karma-mocha": "^0.1.10",
-    "karma-phantomjs-launcher": "^0.1.4",
+    "karma-phantomjs-launcher": "^1.0.2",
     "karma-sauce-launcher": "^0.2.10",
     "karma-webpack": "^1.7.0",
     "mocha": "^2.1.0",


### PR DESCRIPTION
I upgraded the peer dependencies according to the new dev dependencies and the karma-phantom-launcher as the previous version was failing (as per https://github.com/karma-runner/karma-phantomjs-launcher/issues/138)